### PR TITLE
Add form.media to form

### DIFF
--- a/django_modal_actions/templates/admin/django_modal_actions/modal_actions.html
+++ b/django_modal_actions/templates/admin/django_modal_actions/modal_actions.html
@@ -36,3 +36,6 @@
   </form>
   {% endif %}
 </div>
+{% if form %}
+  {{ form.media }}
+{% endif %}


### PR DESCRIPTION
This will probably come in handy...

I've tested this and it was output correctly. And the JS was allowed by the browser.

However, I couldn't use it for anything because Django's AdminSplitDateTime widget is loaded with window.load event, and changing it seemed to require copying the entire JS file.